### PR TITLE
remove unbound type parameters

### DIFF
--- a/src/fglm/fglm.jl
+++ b/src/fglm/fglm.jl
@@ -185,7 +185,7 @@ function fglm_f4(
     ring::PolyRing,
     basisexps::Vector{Vector{ExponentVector}},
     basiscoeffs::Vector{Vector{C}},
-    metainfo) where {Rng,C<:Coeff}
+    metainfo) where {C<:Coeff}
 
     tablesize = select_tablesize(ring, basisexps)
 
@@ -227,7 +227,7 @@ function kbase_f4(
     ring::PolyRing,
     basisexps::Vector{Vector{ExponentVector}},
     basiscoeffs::Vector{Vector{C}},
-    metainfo) where {Rng,C<:Coeff}
+    metainfo) where {C<:Coeff}
 
     tablesize = select_tablesize(ring, basisexps)
 

--- a/src/gb/groebner.jl
+++ b/src/gb/groebner.jl
@@ -95,7 +95,7 @@ function groebner(
             exps::Vector{Vector{ExponentVector}},
             coeffs::Vector{CoeffsVector{T}},
             reduced::Bool,
-            meta::GroebnerMetainfo) where {T<:CoeffQQ, Rng<:Random.AbstractRNG}
+            meta::GroebnerMetainfo) where {T<:CoeffQQ}
 
     # we can mutate coeffs and exps here
 

--- a/src/io.jl
+++ b/src/io.jl
@@ -485,7 +485,7 @@ function convert_to_output(
             origring::M,
             gbexps::Vector{Vector{ExponentVector}},
             gbcoeffs::Vector{Vector{I}},
-            metainfo::GroebnerMetainfo) where {M, T, I}
+            metainfo::GroebnerMetainfo) where {M, I}
 
     @assert hasmethod(base_ring, Tuple{typeof(origring)})
 


### PR DESCRIPTION
I didn't check, but unbound type parameters often cause performance issues, so this may not be merely cosmetic.