### PR TITLE
Bump to 0.3.5 for release with AbstractAlgebra 0.30 support

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Groebner"
 uuid = "0b43b601-686d-58a3-8a1c-6623616c7cd4"
 authors = ["sumiya11"]
-version = "0.3.4"
+version = "0.3.5"
 
 [deps]
 AbstractAlgebra = "c3fe647b-3220-5bb0-a1ea-a7954cac585d"


### PR DESCRIPTION
@sumiya11 , could you consider making a release with support for AbstractAlgebra 0.30?

CompatBot has already taken care of the compat field a few weeks ago.

Such a release would be helpful for me as I have a library that depends on the latest Nemo (which depends on AbstractAlgebra 0.30) but also depends on Symbolics which depends on this package, hence creating a conflict.