### PR TITLE
Release of 0.5.1 in order to fix a downstream dependency clash between Nemo and Symbolics

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Groebner"
 uuid = "0b43b601-686d-58a3-8a1c-6623616c7cd4"
 authors = ["sumiya11"]
-version = "0.5.0"
+version = "0.5.1"
 
 [deps]
 AbstractAlgebra = "c3fe647b-3220-5bb0-a1ea-a7954cac585d"


### PR DESCRIPTION
same issue like #65

Could you consider making a release? I have a downstream package that depends on latest Nemo and on Symbolics and the AbstractAlgebra compat for Groebner is causing a conflict. The compat was updated in #93, but it is not released yet 