### PR TITLE
Use pointer instead of unsafe_convert

### DIFF
--- a/src/utils/simd.jl
+++ b/src/utils/simd.jl
@@ -135,8 +135,8 @@ end
                 ($textir, "entry"),
                 Bool,
                 Tuple{Ptr{T}, Ptr{T}, Int64},
-                Base.unsafe_convert(Ptr{T}, a) + sizeof(T) * offset,
-                Base.unsafe_convert(Ptr{T}, b) + sizeof(T) * offset,
+                pointer(a) + sizeof(T) * offset,
+                pointer(b) + sizeof(T) * offset,
                 length(a) - offset
             )
         end
@@ -235,8 +235,8 @@ end
                 ($textir, "entry"),
                 Bool,
                 Tuple{Ptr{T}, Ptr{T}, Int64},
-                Base.unsafe_convert(Ptr{T}, a) + sizeof(T) * offset,
-                Base.unsafe_convert(Ptr{T}, b) + sizeof(T) * offset,
+                pointer(a) + sizeof(T) * offset,
+                pointer(b) + sizeof(T) * offset,
                 length(a) - offset
             )
         end
@@ -349,8 +349,8 @@ end
                 ($textir, "entry"),
                 Bool,
                 Tuple{Ptr{T}, Ptr{T}, Int64},
-                Base.unsafe_convert(Ptr{T}, a) + sizeof(T) * offset,
-                Base.unsafe_convert(Ptr{T}, b) + sizeof(T) * offset,
+                pointer(a) + sizeof(T) * offset,
+                pointer(b) + sizeof(T) * offset,
                 length(a) - offset
             )
         end
@@ -467,8 +467,8 @@ end
                 ($textir, "entry"),
                 Bool,
                 Tuple{Ptr{T}, Ptr{T}, Int64},
-                Base.unsafe_convert(Ptr{T}, a) + sizeof(T) * offset,
-                Base.unsafe_convert(Ptr{T}, b) + sizeof(T) * offset,
+                pointer(a) + sizeof(T) * offset,
+                pointer(b) + sizeof(T) * offset,
                 length(a) - offset
             )
         end


### PR DESCRIPTION
This fixes the error due to the Base memory buffer change (the `cconvert` for `Array`s returns `MemoryRef` now and the `unsafe_convert` takes in `MemoryRef` rather than `Array` accordingly).

Adding `cconvert` would also work but since the input type is know it's not necessary to do that.