### PR TITLE
Allow the ordering to contain more variables than the input polynomials

### DIFF
--- a/test/groebner.jl
+++ b/test/groebner.jl
@@ -678,7 +678,8 @@ end
 
     # ProductOrdering
     ord = Groebner.Lex(x6, x2) * Groebner.Lex(x4, x1, x3)
-    @test_throws DomainError Groebner.groebner([x1], ordering=ord)
+    @test Groebner.groebner([x1, x2], ordering=ord) == [x1, x2]
+    @test Groebner.groebner([x4, x6, x3], ordering=ord) == [x3, x4, x6]
     @test_throws DomainError Groebner.Lex() * Groebner.Lex(x4, x1, x3)
 
     ord = Groebner.Lex(x6, x2, x5) * Groebner.Lex(x4, x1, x3)

--- a/test/input_output/GroebnerDynamicPolynomialsExt.jl
+++ b/test/input_output/GroebnerDynamicPolynomialsExt.jl
@@ -114,6 +114,11 @@ using DynamicPolynomials, Test
     gb = Groebner.groebner(F, ordering=Groebner.Lex(y, x))
     @test gb == [(-15 // 8) * x + x^3, x * y + (4 // 5) * x^2, (24 // 25) * x + y^3]
 
+    # It is possible to over-specify the ordering
+    @polyvar x y z
+    @test groebner([x, y], ordering=Lex(x, y, z)) == [y, x]
+    @test groebner([x, y], ordering=Lex(y, x, z)) == [x, y]
+
     @polyvar x y monomial_order = Graded{Reverse{InverseLexOrder}}
     F = [2x^2 * y + 3x, 4x * y^2 + 5y^3]
     gb = Groebner.groebner(F)


### PR DESCRIPTION
With this PR, the following does not error:

```julia
using DynamicPolynomials, Groebner
@polyvar x y z
groebner([x, y], ordering=Lex(x, y, z))
```