### PR TITLE
Fix generic integer alignment

### DIFF
--- a/src/f4/sort.jl
+++ b/src/f4/sort.jl
@@ -6,10 +6,16 @@
 # https://github.com/algebraic-solving/msolve/blob/master/COPYING
 
 # y, s.t. y >= x and n | y.
-align_up(x::Integer, n::Integer) = (x + (n - 1)) & (~(n - 1))
+function align_up(x::Integer, n::Integer)
+    @invariant n > 0
+    cld(x, n) * n
+end
 
 # y, s.t y <= x and n | y.
-align_down(x::Integer, n::Integer) = x ⊻ (n - 1)
+function align_down(x::Integer, n::Integer)
+    @invariant n > 0
+    fld(x, n) * n
+end
 
 ### 
 # Sorting monomials, polynomials, and other things.

--- a/src/groebner/groebner.jl
+++ b/src/groebner/groebner.jl
@@ -280,7 +280,7 @@ function _groebner_learn_and_apply(
 
     while !correct_basis
         batch = get_next_batch(primes_used, batch, batch_scaling, composite, tasks)
-        @invariant iszero(batch % composite) && iszero(batch % tasks)
+        @invariant iszero(batch % (composite * tasks))
 
         tasklocal_primes =
             [map(_ -> Int32(modular_next_prime!(state)), 1:div(batch, tasks)) for _ in 1:tasks]

--- a/test/regressions.jl
+++ b/test/regressions.jl
@@ -1,5 +1,24 @@
 using Test, Primes, Groebner, AbstractAlgebra
 
+@testset "regression, generic alignment" begin
+    @test Groebner.align_up(13, 20) == 20
+    @test Groebner.align_up(21, 20) == 40
+    @test Groebner.align_up(29, 20) == 40
+
+    @test Groebner.align_down(13, 20) == 0
+    @test Groebner.align_down(21, 20) == 20
+    @test Groebner.align_down(40, 20) == 40
+
+    for tasks in 1:16
+        composite = 4
+        batch = composite * tasks
+        for primes_used in 1:1000
+            batch = Groebner.get_next_batch(primes_used, batch, 0.1, composite, tasks)
+            @test batch % (composite * tasks) == 0
+        end
+    end
+end
+
 @testset "regression, SI.jl normalform" begin
     R, (x, y, z) = polynomial_ring(GF(2^31 - 1), ["x", "y", "z"])
 


### PR DESCRIPTION
Fixes align_up and align_down for non-power-of-two alignments.

The previous bit-mask implementation only works when the alignment is a power of two, but get_next_batch calls align_up(new_batch, composite * tasks). With non-power-of-two task counts, this can produce a batch size that is not divisible by composite * tasks, which can under-allocate task-local primes in the QQ learn-and-apply modular path.

Changes:
- Use cld(x, n) * n and fld(x, n) * n for generic integer alignment.
- Strengthen the learn-and-apply batch invariant to check divisibility by composite * tasks.
- Add regression coverage for non-power-of-two alignments and get_next_batch across tasks=1:16.

Tested with:
- env JULIA_NUM_THREADS=5 julia --project=. bioh_gb_input.jl
  - Groebner.groebner(polys) completed successfully.
  - The script still fails afterward at quotient_basis(gb) because the ideal is not zero-dimensional.
- env JULIA_NUM_THREADS=5 julia --project=. -e 'using Pkg; Pkg.test(Groebner)'
  - 130033 / 130033 tests passed.