### PR TITLE
Fix a bug in groebner_apply with composite numbers

### DIFF
--- a/src/f4/linalg/backend.jl
+++ b/src/f4/linalg/backend.jl
@@ -693,15 +693,16 @@ function linalg_dense_row_mod_p!(
     nothing
 end
 
+# Returns false when the row has 0 at the first_nnz_index position,
+# but a nonzero was expected.
 function linalg_row_make_monic!(
     row::Vector{T},
     arithmetic::AbstractArithmeticZp{A, T},
     first_nnz_index::Int=1
-) where {A <: Union{CoeffZp, CompositeCoeffZp}, T <: Union{CoeffZp, CompositeCoeffZp}}
-    @invariant !iszero(row[first_nnz_index])
-
+) where {A <: CoeffZp, T <: CoeffZp}
     @inbounds lead = row[first_nnz_index]
-    isone(lead) && return lead
+    iszero(lead) && return false, lead
+    isone(lead) && return true, lead
 
     @inbounds pinv = inv_mod_p(A(lead), arithmetic) % T
     @inbounds row[first_nnz_index] = one(T)
@@ -709,7 +710,26 @@ function linalg_row_make_monic!(
         row[i] = mod_p(A(row[i]) * A(pinv), arithmetic) % T
     end
 
-    pinv
+    true, pinv
+end
+
+function linalg_row_make_monic!(
+    row::Vector{T},
+    arithmetic::AbstractArithmeticZp{A, T},
+    first_nnz_index::Int=1
+) where {A <: CompositeCoeffZp, T <: CompositeCoeffZp}
+    @inbounds lead = row[first_nnz_index]
+    # Composite coefficients are invertible only when every component is nonzero.
+    any(iszero, lead.data) && return false, lead
+    isone(lead) && return true, lead
+
+    @inbounds pinv = inv_mod_p(A(lead), arithmetic) % T
+    @inbounds row[first_nnz_index] = one(T)
+    @inbounds for i in (first_nnz_index + 1):length(row)
+        row[i] = mod_p(A(row[i]) * A(pinv), arithmetic) % T
+    end
+
+    true, pinv
 end
 
 # Generic fallback
@@ -718,10 +738,9 @@ function linalg_row_make_monic!(
     arithmetic::AbstractArithmetic,
     first_nnz_index::Int=1
 ) where {T <: Coeff}
-    @invariant !iszero(row[first_nnz_index])
-
     @inbounds lead = row[first_nnz_index]
-    isone(lead) && return lead
+    iszero(lead) && return false, lead
+    isone(lead) && return true, lead
 
     @inbounds pinv = inv(lead)
     @inbounds row[1] = one(row[1])
@@ -729,7 +748,7 @@ function linalg_row_make_monic!(
         row[i] = row[i] * pinv
     end
 
-    pinv
+    true, pinv
 end
 
 # Linear combination of dense vector and sparse vector

--- a/src/f4/linalg/backend_changematrix.jl
+++ b/src/f4/linalg/backend_changematrix.jl
@@ -114,7 +114,7 @@ function linalg_reduce_matrix_lower_part_changematrix!(
         end
 
         @invariant length(new_sparse_row_support) == length(new_sparse_row_coeffs)
-        pinv = linalg_row_make_monic!(new_sparse_row_coeffs, arithmetic)
+        _, pinv = linalg_row_make_monic!(new_sparse_row_coeffs, arithmetic)
 
         cm2 = empty(cm)
         for ((poly_idx, quo_idx), quo_cf) in cm

--- a/src/f4/linalg/backend_learn_apply.jl
+++ b/src/f4/linalg/backend_learn_apply.jl
@@ -140,7 +140,8 @@ function linalg_apply_reduce_matrix_lower_part!(
         end
 
         @invariant length(new_sparse_row_coeffs) == length(new_sparse_row_support)
-        linalg_row_make_monic!(new_sparse_row_coeffs, arithmetic)
+        success, _ = linalg_row_make_monic!(new_sparse_row_coeffs, arithmetic)
+        !success && return false
 
         # Store the new row in the matrix, AND add it to the active pivots
         matrix.some_coeffs[i] = new_sparse_row_coeffs

--- a/test/regressions.jl
+++ b/test/regressions.jl
@@ -145,6 +145,25 @@ end
     @test true
 end
 
+@testset "regression, non-invertible composite pivot" begin
+    R, (x, y, z) = polynomial_ring(QQ, ["x", "y", "z"])
+
+    # Using a batch of 4 primes, some pivot vanishes modulo the first prime,
+    # but does not vanish modulo the other three primes in the batch.
+    p = BigInt(Primes.prevprime(Groebner.FIRST_LUCKY_PRIME_CANDIDATE - 1))
+    system = [x^2 + p * y + 1, x * y + z + 1]
+
+    gb = Groebner.groebner(system; homogenize=:no, tasks=1, _composite=4)
+    expected = [
+        y^3 + 1 // p * y^2 + 1 // p * z^2 + 2 // p * z + 1 // p,
+        x * z + x - p * y^2 - y,
+        x * y + z + 1,
+        x^2 + p * y + 1
+    ]
+
+    @test gb == expected
+end
+
 # https://github.com/sumiya11/Groebner.jl/issues/175
 @testset "regression, basis" begin
     R, (x1, x2) = polynomial_ring(QQ, ["x1", "x2"], internal_ordering=:deglex)


### PR DESCRIPTION
The bug was produced with the following code, but I don't think I have a smaller example to put in the tests

```julia
using AbstractAlgebra 
using RationalUnivariateRepresentation

function example()
    R, (E_0, E_1, E_2, E_3, E_4, E_5, M_0, M_1, M_2, M_3, M_4, M_5, N_0, N_1, N_2, N_3, N_4, P_0, P_1, P_2, P_3, P_4, P_5, P_6, S_0, S_1, S_2, S_3, S_4, S_5, delta_EL_0, delta_LM_0, delta_NE_0, mu_EE_0, mu_LE_0, mu_LL_0, mu_M_0, mu_N_0, mu_PE_0, mu_PL_0, mu_P_0, rho_E_0, rho_P_0, _Z) = polynomial_ring(QQ, ["E_0", "E_1", "E_2", "E_3", "E_4", "E_5", "M_0", "M_1", "M_2", "M_3", "M_4", "M_5", "N_0", "N_1", "N_2", "N_3", "N_4", "P_0", "P_1", "P_2", "P_3", "P_4", "P_5", "P_6", "S_0", "S_1", "S_2", "S_3", "S_4", "S_5", "delta_EL_0", "delta_LM_0", "delta_NE_0", "mu_EE_0", "mu_LE_0", "mu_LL_0", "mu_M_0", "mu_N_0", "mu_PE_0", "mu_PL_0", "mu_P_0", "rho_E_0", "rho_P_0", "_Z"])
    return [
        -9007199254740992*E_0 + 5571065020643727,
        E_0^2*mu_EE_0^2 - E_0*P_0*rho_E_0^2 + E_0*delta_EL_0 + E_1 - N_0*P_0*delta_NE_0,
        -18014398509481984*N_0 + 8104952581767281,
        N_0*P_0*delta_NE_0^2 + N_0*mu_N_0^2 + N_1,
        -9007199254740992*P_0 + 5382591549500495,
        E_0*P_0*mu_PE_0 - P_0^2*rho_P_0 + P_0*S_0*mu_PL_0 + P_0*mu_P_0 + P_1,
        -2251799813685248*M_0 - 2251799813685248*S_0 + 2947593697568269,
        M_0*mu_M_0 + M_1 - S_0*delta_LM_0,
        E_0*S_0*mu_LE_0 + S_0^2*mu_LL_0 - S_0*delta_EL_0 + S_0*delta_LM_0 + S_1,
        -9007199254740992*E_1 - 6276059674434263,
        2*E_0*E_1*mu_EE_0^2 - E_0*P_1*rho_E_0^2 - E_1*P_0*rho_E_0^2 + E_1*delta_EL_0 + E_2 - N_0*P_1*delta_NE_0 - N_1*P_0*delta_NE_0,
        -9007199254740992*N_1 - 6474186305390003,
        N_0*P_1*delta_NE_0^2 + N_1*P_0*delta_NE_0^2 + N_1*mu_N_0^2 + N_2,
        -2251799813685248*P_1 - 1426109608481743,
        E_0*P_1*mu_PE_0 + E_1*P_0*mu_PE_0 - 2*P_0*P_1*rho_P_0 + P_0*S_1*mu_PL_0 + P_1*S_0*mu_PL_0 + P_1*mu_P_0 + P_2,
        -4503599627370496*M_1 - 4503599627370496*S_1 - 4676713465621913,
        E_0*S_1*mu_LE_0 + E_1*S_0*mu_LE_0 + 2*S_0*S_1*mu_LL_0 - S_1*delta_EL_0 + S_1*delta_LM_0 + S_2,
        M_1*mu_M_0 + M_2 - S_1*delta_LM_0,
        -9007199254740992*E_2 + 7065409620925765,
        2*E_0*E_2*mu_EE_0^2 - E_0*P_2*rho_E_0^2 + 2*E_1^2*mu_EE_0^2 - 2*E_1*P_1*rho_E_0^2 - E_2*P_0*rho_E_0^2 + E_2*delta_EL_0 + E_3 - N_0*P_2*delta_NE_0 - 2*N_1*P_1*delta_NE_0 - N_2*P_0*delta_NE_0,
        -4503599627370496*N_2 + 6454797145036891,
        N_0*P_2*delta_NE_0^2 + 2*N_1*P_1*delta_NE_0^2 + N_2*P_0*delta_NE_0^2 + N_2*mu_N_0^2 + N_3,
        -9007199254740992*P_2 + 6955203024110299,
        E_0*P_2*mu_PE_0 + 2*E_1*P_1*mu_PE_0 + E_2*P_0*mu_PE_0 - 2*P_0*P_2*rho_P_0 + P_0*S_2*mu_PL_0 - 2*P_1^2*rho_P_0 + 2*P_1*S_1*mu_PL_0 + P_2*S_0*mu_PL_0 + P_2*mu_P_0 + P_3,
        -4503599627370496*M_2 - 4503599627370496*S_2 + 5981257980333709,
        E_0*S_2*mu_LE_0 + 2*E_1*S_1*mu_LE_0 + E_2*S_0*mu_LE_0 + 2*S_0*S_2*mu_LL_0 + 2*S_1^2*mu_LL_0 - S_2*delta_EL_0 + S_2*delta_LM_0 + S_3,
        M_2*mu_M_0 + M_3 - S_2*delta_LM_0,
        -18014398509481984*E_3 - 8458257683871469,
        2*E_0*E_3*mu_EE_0^2 - E_0*P_3*rho_E_0^2 + 6*E_1*E_2*mu_EE_0^2 - 3*E_1*P_2*rho_E_0^2 - 3*E_2*P_1*rho_E_0^2 - E_3*P_0*rho_E_0^2 + E_3*delta_EL_0 + E_4 - N_0*P_3*delta_NE_0 - 3*N_1*P_2*delta_NE_0 - 3*N_2*P_1*delta_NE_0 - N_3*P_0*delta_NE_0,
        -2251799813685248*P_3 - 3496410063957621,
        E_0*P_3*mu_PE_0 + 3*E_1*P_2*mu_PE_0 + 3*E_2*P_1*mu_PE_0 + E_3*P_0*mu_PE_0 - 2*P_0*P_3*rho_P_0 + P_0*S_3*mu_PL_0 - 6*P_1*P_2*rho_P_0 + 3*P_1*S_2*mu_PL_0 + 3*P_2*S_1*mu_PL_0 + P_3*S_0*mu_PL_0 + P_3*mu_P_0 + P_4,
        -2251799813685248*M_3 - 2251799813685248*S_3 - 7083564008501585,
        E_0*S_3*mu_LE_0 + 3*E_1*S_2*mu_LE_0 + 3*E_2*S_1*mu_LE_0 + E_3*S_0*mu_LE_0 + 2*S_0*S_3*mu_LL_0 + 6*S_1*S_2*mu_LL_0 - S_3*delta_EL_0 + S_3*delta_LM_0 + S_4,
        M_3*mu_M_0 + M_4 - S_3*delta_LM_0,
        -1125899906842624*P_4 + 6179186939669291,
        E_0*P_4*mu_PE_0 + 4*E_1*P_3*mu_PE_0 + 6*E_2*P_2*mu_PE_0 + 4*E_3*P_1*mu_PE_0 + E_4*P_0*mu_PE_0 - 2*P_0*P_4*rho_P_0 + P_0*S_4*mu_PL_0 - 8*P_1*P_3*rho_P_0 + 4*P_1*S_3*mu_PL_0 - 6*P_2^2*rho_P_0 + 6*P_2*S_2*mu_PL_0 + 4*P_3*S_1*mu_PL_0 + P_4*S_0*mu_PL_0 + P_4*mu_P_0 + P_5,
        -562949953421312*M_4 - 562949953421312*S_4 + 7279546489327717,
        M_4*mu_M_0 + M_5 - S_4*delta_LM_0,
        E_0*S_4*mu_LE_0 + 4*E_1*S_3*mu_LE_0 + 6*E_2*S_2*mu_LE_0 + 4*E_3*S_1*mu_LE_0 + E_4*S_0*mu_LE_0 + 2*S_0*S_4*mu_LL_0 + 8*S_1*S_3*mu_LL_0 + 6*S_2^2*mu_LL_0 - S_4*delta_EL_0 + S_4*delta_LM_0 + S_5,
        -4398046511104*P_5 - 109700988492031,
        E_0*P_5*mu_PE_0 + 5*E_1*P_4*mu_PE_0 + 10*E_2*P_3*mu_PE_0 + 10*E_3*P_2*mu_PE_0 + 5*E_4*P_1*mu_PE_0 + E_5*P_0*mu_PE_0 - 2*P_0*P_5*rho_P_0 + P_0*S_5*mu_PL_0 - 10*P_1*P_4*rho_P_0 + 5*P_1*S_4*mu_PL_0 - 20*P_2*P_3*rho_P_0 + 10*P_2*S_3*mu_PL_0 + 10*P_3*S_2*mu_PL_0 + 5*P_4*S_1*mu_PL_0 + P_5*S_0*mu_PL_0 + P_5*mu_P_0 + P_6,
        2*E_0*E_4*mu_EE_0^2 - E_0*P_4*rho_E_0^2 + 8*E_1*E_3*mu_EE_0^2 - 4*E_1*P_3*rho_E_0^2 + 6*E_2^2*mu_EE_0^2 - 6*E_2*P_2*rho_E_0^2 - 4*E_3*P_1*rho_E_0^2 - E_4*P_0*rho_E_0^2 + E_4*delta_EL_0 + E_5 - N_0*P_4*delta_NE_0 - 4*N_1*P_3*delta_NE_0 - 6*N_2*P_2*delta_NE_0 - 4*N_3*P_1*delta_NE_0 - N_4*P_0*delta_NE_0,
        N_0*P_3*delta_NE_0^2 + 3*N_1*P_2*delta_NE_0^2 + 3*N_2*P_1*delta_NE_0^2 + N_3*P_0*delta_NE_0^2 + N_3*mu_N_0^2 + N_4,
        -26*E_0 + 10*E_1 + 5*E_2 - 41*E_3 - 35*E_4 + 67*E_5 - 23*M_0 - 34*M_1 + 9*M_2 + 41*M_3 - 33*M_4 - 28*M_5 + 32*N_0 + 47*N_1 - 4*N_2 + 82*N_3 + 46*N_4 + 62*P_0 + 16*P_1 + 4*P_2 + 84*P_3 - 4*P_4 + 61*P_5 - 21*P_6 + 21*S_0 + 37*S_1 + 14*S_2 - 72*S_3 + 37*S_4 - 13*S_5 + 36*delta_EL_0 + 69*delta_LM_0 - 45*delta_NE_0 + 26*mu_EE_0 + 94*mu_LE_0 + 85*mu_LL_0 - 33*mu_M_0 + 2*mu_N_0 - 43*mu_PE_0 + 67*mu_PL_0 - 6*mu_P_0 + 8*rho_E_0 - 71*rho_P_0 + _Z
    ]
end

zdim_parameterization(example())
```