### PR TITLE
Fix CRT MethodError on 32-bit Julia (UInt vs UInt64)

### DIFF
--- a/.github/workflows/Runtests.yml
+++ b/.github/workflows/Runtests.yml
@@ -22,14 +22,12 @@ jobs:
         os: [ubuntu-latest]
 
         include:
-          # One additional 32-bit Linux job
           - julia-version: '1'
             julia-arch: x86
             os: ubuntu-latest
 
-          # Add Windows and macOS jobs
           - julia-version: '1'
-            julia-arch: x64
+            julia-arch: aarch64
             os: macOS-latest
 
           - julia-version: '1'

--- a/.github/workflows/Runtests.yml
+++ b/.github/workflows/Runtests.yml
@@ -1,49 +1,72 @@
 name: Runtests
+
 on:
   push:
     branches:
       - 'master'
     tags: '*'
   pull_request:
+
 env:
   JULIA_NUM_THREADS: 4
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}
+
     strategy:
+      fail-fast: false
       matrix:
-        julia-version: ['1'] # Can also add 'nightly'
+        julia-version: ['1']
         julia-arch: [x64]
         os: [ubuntu-latest]
+
         include:
-            # Add a few windows and macOS jobs
-            - julia-version: '1'
-              os: macOS-latest
-            - julia-version: '1'
-              os: windows-latest
+          # One additional 32-bit Linux job
+          - julia-version: '1'
+            julia-arch: x86
+            os: ubuntu-latest
+
+          # Add Windows and macOS jobs
+          - julia-version: '1'
+            julia-arch: x64
+            os: macOS-latest
+
+          - julia-version: '1'
+            julia-arch: x64
+            os: windows-latest
+
     steps:
       - uses: actions/checkout@v4
-      - uses: julia-actions/setup-julia@latest
+
+      - uses: julia-actions/setup-julia@v3
         with:
           version: ${{ matrix.julia-version }}
+          arch: ${{ matrix.julia-arch }}
+
+      - name: Show Julia architecture
+        run: julia -e 'println("Julia ", VERSION, ", ", Sys.WORD_SIZE, "-bit, Int = ", Int)'
+
       - uses: actions/cache@v4
         env:
           cache-name: cache-artifacts
         with:
           path: ~/.julia/artifacts
-          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
+          key: ${{ runner.os }}-${{ matrix.julia-arch }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
           restore-keys: |
-            ${{ runner.os }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-test-
-            ${{ runner.os }}-
+            ${{ runner.os }}-${{ matrix.julia-arch }}-test-${{ env.cache-name }}-
+            ${{ runner.os }}-${{ matrix.julia-arch }}-test-
+
       - uses: julia-actions/julia-buildpkg@latest
+
       - uses: julia-actions/julia-runtest@latest
         with:
           depwarn: error
+
       - uses: julia-actions/julia-processcoverage@v1
+
       - uses: codecov/codecov-action@v5
         with:
           file: lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}
-          verbose: true # optional (default = false)
-  
+          verbose: true

--- a/.github/workflows/Runtests.yml
+++ b/.github/workflows/Runtests.yml
@@ -13,6 +13,7 @@ env:
 jobs:
   test:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: ${{ matrix.timeout-minutes }}
 
     strategy:
       fail-fast: false
@@ -20,22 +21,34 @@ jobs:
         julia-version: ['1']
         julia-arch: [x64]
         os: [ubuntu-latest]
+        timeout-minutes: [120]
 
         include:
           - julia-version: '1'
             julia-arch: x86
             os: ubuntu-latest
+            timeout-minutes: 360
 
           - julia-version: '1'
             julia-arch: aarch64
             os: macOS-latest
+            timeout-minutes: 120
 
           - julia-version: '1'
             julia-arch: x64
             os: windows-latest
+            timeout-minutes: 120
 
     steps:
       - uses: actions/checkout@v4
+
+      # Julia x86 on Ubuntu needs the i386 loader/libs or spawn fails / hangs oddly.
+      - name: Install 32-bit runtime libraries (i386)
+        if: matrix.julia-arch == 'x86' && runner.os == 'Linux'
+        run: |
+          sudo dpkg --add-architecture i386
+          sudo apt-get update
+          sudo apt-get install -y libc6:i386 libstdc++6:i386 libgfortran5:i386
 
       - uses: julia-actions/setup-julia@v3
         with:

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,7 @@
 name = "Groebner"
 uuid = "0b43b601-686d-58a3-8a1c-6623616c7cd4"
-version = "0.10.7"
+version = "0.10.8"
+version = "0.10.8"
 authors = ["sumiya11"]
 
 [deps]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,6 @@
 name = "Groebner"
 uuid = "0b43b601-686d-58a3-8a1c-6623616c7cd4"
 version = "0.10.8"
-version = "0.10.8"
 authors = ["sumiya11"]
 
 [deps]

--- a/src/input_output/AbstractAlgebra.jl
+++ b/src/input_output/AbstractAlgebra.jl
@@ -9,7 +9,8 @@
 # https://github.com/Nemocas/AbstractAlgebra.jl/issues/1542
 
 const aa_supported_orderings = (:lex, :deglex, :degrevlex)
-const aa_exponent_type = UInt64
+# AbstractAlgebra.Generic.MPoly expects Matrix{UInt} (UInt32 on 32-bit, UInt64 on 64-bit).
+const aa_exponent_type = UInt
 
 aa_is_multivariate_ring(ring) = AbstractAlgebra.elem_type(ring) <: AbstractAlgebra.MPolyRingElem
 

--- a/src/reconstruction/crt.jl
+++ b/src/reconstruction/crt.jl
@@ -60,11 +60,14 @@ Writes the answer to `buf` inplace.
 - `ci`: an array of numbers, with `ci[i] = πi * invmod(πi, mi)`, `πi = M / mi`
 
 Then, `x` is obtained as `x = ∑ ci[i] ai[i] mod M`.
+
+Always use `UInt64` buffers so 32-bit Julia (`UInt === UInt32`) can still
+carry moduli larger than `typemax(UInt32)`.
 """
-function crt!(M::BigInt, buf::BigInt, n1::BigInt, n2::BigInt, ai::Vector{UInt}, ci::Vector{BigInt})
+function crt!(M::BigInt, buf::BigInt, n1::BigInt, n2::BigInt, ai::Vector{UInt64}, ci::Vector{BigInt})
     @invariant length(ai) == length(ci)
 
-    my_set_ui!(n1, UInt(0))
+    my_set_ui!(n1, UInt64(0))
     for i in 1:length(ai)
         my_mul_ui!(n2, ci[i], ai[i])
         Base.GMP.MPZ.add!(n1, n2)
@@ -88,7 +91,7 @@ function crt_precompute!(
     n1::BigInt,
     n2::BigInt,
     ci::Vector{BigInt},
-    moduli::Vector{UInt}
+    moduli::Vector{UInt64}
 )
     @invariant length(ci) == length(moduli)
 
@@ -131,13 +134,13 @@ end
         mults[i] = BigInt()
     end
 
-    crt_precompute!(modulo, n1, n2, mults, map(UInt, moduli))
+    crt_precompute!(modulo, n1, n2, mults, map(UInt64, moduli))
 
-    rems = Vector{UInt}(undef, length(moduli))
+    rems = Vector{UInt64}(undef, length(moduli))
     @inbounds for k in 1:length(witness_set)
         i, j = witness_set[k]
         for t in 1:length(moduli)
-            rems[t] = UInt(tables_ff[t][i][j])
+            rems[t] = UInt64(tables_ff[t][i][j])
         end
         crt!(modulo, buf, n1, n2, rems, mults)
         Base.GMP.MPZ.set!(table_zz[i][j], buf)
@@ -153,7 +156,7 @@ function _crt_vec_full!(
     buf::BigInt,
     n1::BigInt,
     n2::BigInt,
-    rems::Vector{UInt},
+    rems::Vector{UInt64},
     tables_ff::Vector{Vector{Vector{T}}},
     mults::Vector{BigInt},
     moduli::Vector{U},
@@ -166,7 +169,7 @@ function _crt_vec_full!(
             mask[i][j] && continue
             for k in 1:length(moduli)
                 @invariant 0 <= tables_ff[k][i][j] < moduli[k]
-                rems[k] = UInt(tables_ff[k][i][j])
+                rems[k] = UInt64(tables_ff[k][i][j])
             end
             crt!(modulo, buf, n1, n2, rems, mults)
             Base.GMP.MPZ.set!(table_zz[i][j], buf)
@@ -194,7 +197,7 @@ end
         mults[i] = BigInt()
     end
 
-    crt_precompute!(modulo, n1, n2, mults, map(UInt, moduli))
+    crt_precompute!(modulo, n1, n2, mults, map(UInt64, moduli))
 
     tasks = min(tasks, length(table_zz))
     data_chunks = split_round_robin(1:length(table_zz), tasks)
@@ -202,7 +205,7 @@ end
     for (tid, chunk) in enumerate(data_chunks)
         task = @spawn begin
             local buf, n1, n2 = BigInt(), BigInt(), BigInt()
-            local rems = Vector{UInt}(undef, length(moduli))
+            local rems = Vector{UInt64}(undef, length(moduli))
             _crt_vec_full!(
                 table_zz,
                 modulo,

--- a/src/reconstruction/crt.jl
+++ b/src/reconstruction/crt.jl
@@ -64,7 +64,14 @@ Then, `x` is obtained as `x = ∑ ci[i] ai[i] mod M`.
 Always use `UInt64` buffers so 32-bit Julia (`UInt === UInt32`) can still
 carry moduli larger than `typemax(UInt32)`.
 """
-function crt!(M::BigInt, buf::BigInt, n1::BigInt, n2::BigInt, ai::Vector{UInt64}, ci::Vector{BigInt})
+function crt!(
+    M::BigInt,
+    buf::BigInt,
+    n1::BigInt,
+    n2::BigInt,
+    ai::Vector{UInt64},
+    ci::Vector{BigInt}
+)
     @invariant length(ai) == length(ci)
 
     my_set_ui!(n1, UInt64(0))

--- a/src/reconstruction/crt.jl
+++ b/src/reconstruction/crt.jl
@@ -5,38 +5,41 @@
 
 # Auxiliary functions allowing to avoid overflow
 # on Windows for numbers between 32 and 64 bits
-function my_set_ui!(a::BigInt, b::UInt64)
+function my_set_ui!(a::BigInt, b::Unsigned)
+    bb = b % UInt64
     @static if Culong == UInt64
-        Base.GMP.MPZ.set_ui!(a, b)
+        Base.GMP.MPZ.set_ui!(a, bb)
     else
-        if b < 2^32
-            Base.GMP.MPZ.set_ui!(a, b)
+        if bb < 2^32
+            Base.GMP.MPZ.set_ui!(a, bb)
         else
-            Base.GMP.MPZ.set!(a, BigInt(b))
+            Base.GMP.MPZ.set!(a, BigInt(bb))
         end
     end
 end
 
-function my_mul_ui!(a::BigInt, b::BigInt, c::UInt64)
+function my_mul_ui!(a::BigInt, b::BigInt, c::Unsigned)
+    cc = c % UInt64
     @static if Culong == UInt64
-        Base.GMP.MPZ.mul_ui!(a, b, c)
+        Base.GMP.MPZ.mul_ui!(a, b, cc)
     else
-        if c < 2^32
-            Base.GMP.MPZ.mul_ui!(a, b, c)
+        if cc < 2^32
+            Base.GMP.MPZ.mul_ui!(a, b, cc)
         else
-            Base.GMP.MPZ.mul!(a, b, BigInt(c))
+            Base.GMP.MPZ.mul!(a, b, BigInt(cc))
         end
     end
 end
 
-function my_mul_ui!(a::BigInt, b::UInt64)
+function my_mul_ui!(a::BigInt, b::Unsigned)
+    bb = b % UInt64
     @static if Culong == UInt64
-        Base.GMP.MPZ.mul_ui!(a, b)
+        Base.GMP.MPZ.mul_ui!(a, bb)
     else
-        if b < 2^32
-            Base.GMP.MPZ.mul_ui!(a, b)
+        if bb < 2^32
+            Base.GMP.MPZ.mul_ui!(a, bb)
         else
-            Base.GMP.MPZ.mul!(a, BigInt(b))
+            Base.GMP.MPZ.mul!(a, BigInt(bb))
         end
     end
 end
@@ -128,13 +131,13 @@ end
         mults[i] = BigInt()
     end
 
-    crt_precompute!(modulo, n1, n2, mults, map(UInt64, moduli))
+    crt_precompute!(modulo, n1, n2, mults, map(UInt, moduli))
 
-    rems = Vector{UInt64}(undef, length(moduli))
+    rems = Vector{UInt}(undef, length(moduli))
     @inbounds for k in 1:length(witness_set)
         i, j = witness_set[k]
         for t in 1:length(moduli)
-            rems[t] = UInt64(tables_ff[t][i][j])
+            rems[t] = UInt(tables_ff[t][i][j])
         end
         crt!(modulo, buf, n1, n2, rems, mults)
         Base.GMP.MPZ.set!(table_zz[i][j], buf)
@@ -150,7 +153,7 @@ function _crt_vec_full!(
     buf::BigInt,
     n1::BigInt,
     n2::BigInt,
-    rems::Vector{UInt64},
+    rems::Vector{UInt},
     tables_ff::Vector{Vector{Vector{T}}},
     mults::Vector{BigInt},
     moduli::Vector{U},
@@ -163,7 +166,7 @@ function _crt_vec_full!(
             mask[i][j] && continue
             for k in 1:length(moduli)
                 @invariant 0 <= tables_ff[k][i][j] < moduli[k]
-                rems[k] = UInt64(tables_ff[k][i][j])
+                rems[k] = UInt(tables_ff[k][i][j])
             end
             crt!(modulo, buf, n1, n2, rems, mults)
             Base.GMP.MPZ.set!(table_zz[i][j], buf)
@@ -191,7 +194,7 @@ end
         mults[i] = BigInt()
     end
 
-    crt_precompute!(modulo, n1, n2, mults, map(UInt64, moduli))
+    crt_precompute!(modulo, n1, n2, mults, map(UInt, moduli))
 
     tasks = min(tasks, length(table_zz))
     data_chunks = split_round_robin(1:length(table_zz), tasks)
@@ -199,7 +202,7 @@ end
     for (tid, chunk) in enumerate(data_chunks)
         task = @spawn begin
             local buf, n1, n2 = BigInt(), BigInt(), BigInt()
-            local rems = Vector{UInt64}(undef, length(moduli))
+            local rems = Vector{UInt}(undef, length(moduli))
             _crt_vec_full!(
                 table_zz,
                 modulo,

--- a/test/auxiliary.jl
+++ b/test/auxiliary.jl
@@ -48,7 +48,7 @@ end
     @test_throws DomainError Groebner.quotient_basis([R(0)])
 
     for k in [
-        AbstractAlgebra.GF(2^30 + 3),
+        AbstractAlgebra.GF(Int64(2)^30 + 3),
         fraction_field(AbstractAlgebra.QQ["t"][1]),
         AbstractAlgebra.QQ
     ]
@@ -73,7 +73,7 @@ end
     @test_throws DomainError Groebner.dimension([])
 
     n = 100
-    R, x = polynomial_ring(AbstractAlgebra.GF(2^30 + 3), ["x$i" for i in 1:n])
+    R, x = polynomial_ring(AbstractAlgebra.GF(Int64(2)^30 + 3), ["x$i" for i in 1:n])
     @test Groebner.dimension([sum(x)]) == n - 1
     @test Groebner.dimension([sum(x), prod(x), sum([i for i in 1:n] .* x)]) == n - 3
 end

--- a/test/groebner.jl
+++ b/test/groebner.jl
@@ -1,7 +1,7 @@
 using Test, AbstractAlgebra, Base.Threads, Combinatorics, Primes, Random, Groebner
 
 @testset "groebner basic" begin
-    R, (x, y) = polynomial_ring(GF(2^31 - 1), ["x", "y"], internal_ordering=:degrevlex)
+    R, (x, y) = polynomial_ring(GF(Int64(2)^31 - 1), ["x", "y"], internal_ordering=:degrevlex)
 
     @test_throws DomainError Groebner.groebner([])
     @test_throws DomainError Groebner.groebner([1])
@@ -14,7 +14,7 @@ using Test, AbstractAlgebra, Base.Threads, Combinatorics, Primes, Random, Groebn
     @test Groebner.groebner([x^2 + y, y * x - 1, R(1), y^4]) == [R(1)]
     @test Groebner.groebner([2x, 3y, 4x + 5y]) == [y, x]
 
-    R, (x1, x2) = polynomial_ring(GF(2^31 - 1), ["x1", "x2"], internal_ordering=:degrevlex)
+    R, (x1, x2) = polynomial_ring(GF(Int64(2)^31 - 1), ["x1", "x2"], internal_ordering=:degrevlex)
 
     fs = [x1^2 * x2^2 + 2 * x1^2 * x2, x1^2 * x2^2 + 3 * x1^2 * x2 + 5 * x1 * x2^2, x1^2 * x2^2]
     @test Groebner.groebner(fs) == [x1 * x2^2, x1^2 * x2]
@@ -40,8 +40,8 @@ function test_low_level_interface(ring, sys; passthrough...)
 end
 
 @testset "groebner low level" begin
-    R, (x, y) = polynomial_ring(GF(2^31 - 1), ["x", "y"], internal_ordering=:degrevlex)
-    ring_ff = Groebner.PolyRing(2, Groebner.DegRevLex(), 2^31 - 1)
+    R, (x, y) = polynomial_ring(GF(Int64(2)^31 - 1), ["x", "y"], internal_ordering=:degrevlex)
+    ring_ff = Groebner.PolyRing(2, Groebner.DegRevLex(), Int64(2)^31 - 1)
     ring_ff2 = Groebner.PolyRing(2, Groebner.DegRevLex(), 2^32 - 5)
     ring_qq = Groebner.PolyRing(2, Groebner.DegRevLex(), 0)
 
@@ -56,7 +56,7 @@ end
         [[1]]
     )
     @test_throws DomainError Groebner.groebner(
-        Groebner.PolyRing(2, Groebner.InputOrdering(), 2^31 - 1),
+        Groebner.PolyRing(2, Groebner.InputOrdering(), Int64(2)^31 - 1),
         [[[0, 0]]],
         [[1]]
     )
@@ -95,17 +95,17 @@ end
           Groebner.groebner(ring_ff, [[[0, 1], [0, 0], [0, 0]]], [[1, 2, 3]])
     @test ([[[0, 1], [0, 0]]], [[1, 5]]) ==
           Groebner.groebner(ring_qq, [[[0, 1], [0, 0], [0, 0]]], [[1, 2, 3]])
-    @test ([[[0, 1], [0, 0]]], [[1, 2^31 - 2]]) ==
+    @test ([[[0, 1], [0, 0]]], [[1, Int64(2)^31 - 2]]) ==
           Groebner.groebner(ring_ff, [[[0, 1], [0, 0], [0, 0]]], [[1, 2, -3]])
     @test ([[[0, 1]]], [[1]]) ==
           Groebner.groebner(ring_ff, [[[0, 1], [0, 0], [0, 0]]], [[1, 3, -3]])
     @test ([Vector{Vector{Int}}()], [Int[]]) == Groebner.groebner(ring_ff, [[[0, 1]]], [[0]])
     @test ([Vector{Vector{Int}}()], [Int[]]) == Groebner.groebner(ring_qq, [[[0, 1]]], [[0]])
-    @test ([[[1, 1]]], [[1]]) == Groebner.groebner(ring_ff, [[[1, 1]]], [[2^31]])
+    @test ([[[1, 1]]], [[1]]) == Groebner.groebner(ring_ff, [[[1, 1]]], [[Int64(2)^31]])
     @test ([[[1, 1], [1, 0]]], [[1, 5]]) == Groebner.groebner(
         ring_ff2,
         [[[1, 1], [1, 0], [1, 0], [0, 0], [0, 0], [0, 0]]],
-        [[1, 2^31, 2^31, 2^31, 2^31, -5]]
+        [[1, Int64(2)^31, Int64(2)^31, Int64(2)^31, Int64(2)^31, -5]]
     )
 
     # Sorting on the fly
@@ -113,8 +113,8 @@ end
     @test ([[[1, 1], [0, 0]]], [[1, 3 // 4]]) ==
           Groebner.groebner(ring_qq, [[[0, 0], [1, 1]]], [[3, 4]])
 
-    ring_gf = Groebner.PolyRing(5, Groebner.Lex(), 2^30 + 3)
-    sys = Groebner.Examples.cyclicn(5, k=GF(2^30 + 3), internal_ordering=:lex)
+    ring_gf = Groebner.PolyRing(5, Groebner.Lex(), Int64(2)^30 + 3)
+    sys = Groebner.Examples.cyclicn(5, k=GF(Int64(2)^30 + 3), internal_ordering=:lex)
     perm = map(i -> shuffle(collect(1:length(sys[i]))), 1:length(sys))
     monoms = map(i -> collect(exponent_vectors(sys[i]))[perm[i]], 1:length(sys))
     coeffs = map(i -> collect(UInt64.(lift.(coefficients(sys[i]))))[perm[i]], 1:length(sys))
@@ -135,8 +135,8 @@ end
     ring = Groebner.PolyRing(5, Groebner.DegRevLex(), 2^40 + 15)
     test_low_level_interface(ring, sys)
 
-    sys = Groebner.Examples.cyclicn(5, k=GF(2^30 + 3), internal_ordering=:lex)
-    ring = Groebner.PolyRing(5, Groebner.Lex(), 2^30 + 3)
+    sys = Groebner.Examples.cyclicn(5, k=GF(Int64(2)^30 + 3), internal_ordering=:lex)
+    ring = Groebner.PolyRing(5, Groebner.Lex(), Int64(2)^30 + 3)
     test_low_level_interface(ring, sys)
 
     sys = Groebner.Examples.cyclicn(5, k=QQ)
@@ -199,7 +199,7 @@ end
 end
 
 @testset "groebner reduced=false" begin
-    R, (x, y) = polynomial_ring(GF(2^31 - 1), ["x", "y"], internal_ordering=:lex)
+    R, (x, y) = polynomial_ring(GF(Int64(2)^31 - 1), ["x", "y"], internal_ordering=:lex)
 
     fs = [x + y^2, x * y - y^2]
     gb = Groebner.groebner(fs, reduced=false)
@@ -229,16 +229,16 @@ end
 @testset "groebner ground fields" begin
     # Large fields
     fields = [
-        GF(2^20 + 7),
-        GF(2^29 - 3),
-        GF(2^29 + 11),
-        GF(2^30 - 35),
-        GF(2^30 + 3),
-        GF(2^31 - 1),
-        GF(2^31 + 11),
-        GF(2^32 + 15)
+        GF(Int64(2)^20 + 7),
+        GF(Int64(2)^29 - 3),
+        GF(Int64(2)^29 + 11),
+        GF(Int64(2)^30 - 35),
+        GF(Int64(2)^30 + 3),
+        GF(Int64(2)^31 - 1),
+        GF(Int64(2)^31 + 11),
+        GF(Int64(2)^32 + 15)
     ]
-    fields = vcat(fields, map(GF, Primes.nextprimes(2^20, 10)))
+    fields = vcat(fields, map(GF, Primes.nextprimes(Int64(2)^20, 10)))
     for field in fields
         R, (x, y) = field["x", "y"]
 
@@ -312,18 +312,18 @@ end
         @test Groebner.groebner([4x + 1], modular=modular) == [x + 1 // 4]
         @test Groebner.groebner([x + 5], modular=modular) == [x + 5]
         @test Groebner.groebner([x + 2^10], modular=modular) == [x + 2^10]
-        @test Groebner.groebner([x + 2^30], modular=modular) == [x + 2^30]
-        @test Groebner.groebner([x + 2^30 + 3], modular=modular) == [x + 2^30 + 3]
-        @test Groebner.groebner([x + 2^31 - 1], modular=modular) == [x + 2^31 - 1]
-        @test Groebner.groebner([x + 2^31 - 1, x^2], modular=modular) == [1]
+        @test Groebner.groebner([x + Int64(2)^30], modular=modular) == [x + Int64(2)^30]
+        @test Groebner.groebner([x + Int64(2)^30 + 3], modular=modular) == [x + Int64(2)^30 + 3]
+        @test Groebner.groebner([x + Int64(2)^31 - 1], modular=modular) == [x + Int64(2)^31 - 1]
+        @test Groebner.groebner([x + Int64(2)^31 - 1, x^2], modular=modular) == [1]
         @test Groebner.groebner([(3232323 // 7777)x + 7777 // 3232323], modular=modular) ==
               [x + 60481729 // 10447911976329]
-        @test Groebner.groebner([((2^31 - 1) // 1)x + 1], modular=modular) == [x + 1 // 2147483647]
-        @test Groebner.groebner([(1 // (2^31 - 1))x + 1], modular=modular) == [x + 2147483647]
+        @test Groebner.groebner([((Int64(2)^31 - 1) // 1)x + 1], modular=modular) == [x + 1 // 2147483647]
+        @test Groebner.groebner([(1 // (Int64(2)^31 - 1))x + 1], modular=modular) == [x + 2147483647]
         @test Groebner.groebner(
-            [1 // (2^30 + 3) * x^2 + (2^30 + 3)x + 1 // (1073741831)],
+            [1 // (Int64(2)^30 + 3) * x^2 + (Int64(2)^30 + 3)x + 1 // (1073741831)],
             modular=modular
-        ) == [x^2 + 1152921511049297929x + (2^30 + 3) // 1073741831]
+        ) == [x^2 + 1152921511049297929x + (Int64(2)^30 + 3) // 1073741831]
 
         R, (x, y) = polynomial_ring(QQ, ["x", "y"], internal_ordering=:degrevlex)
 
@@ -412,11 +412,11 @@ end
         w^3
     ]
 
-    G = [(2^30 + 3)x, (1 // (2^30 + 3))y]
+    G = [(Int64(2)^30 + 3)x, (1 // (Int64(2)^30 + 3))y]
     G = Groebner.groebner(G)
     @test G == [y, x]
 
-    G = [(2^31 - 1) * x + y, (1 // (2^31 - 1)) * y + 1]
+    G = [(Int64(2)^31 - 1) * x + y, (1 // (Int64(2)^31 - 1)) * y + 1]
     G = Groebner.groebner(G)
     @test G == [y + 2147483647, x - 1]
 
@@ -425,14 +425,14 @@ end
     G = Groebner.groebner(fs)
     @test G == [y + 2131232232097 // 222222221111123 * z, x]
 
-    P = prod(BigInt, prevprimes(2^31, 100))
+    P = prod(BigInt, prevprimes(Int64(2)^31, 100))
     @test groebner([x^2 + P * x + 1]) == [x^2 + P * x + 1]
 
     @test isgroebner(groebner(Groebner.Examples.cyclicn(7)))
 end
 
 @testset "groebner output sorted" begin
-    for K in [GF(11), GF(307), GF(12007), GF(2^31 - 1), QQ]
+    for K in [GF(11), GF(307), GF(12007), GF(Int64(2)^31 - 1), QQ]
         R, (x, y, z) = polynomial_ring(K, ["x", "y", "z"], internal_ordering=:lex)
 
         @test Groebner.groebner([x, y]) == Groebner.groebner([y, x]) == [y, x]
@@ -442,10 +442,10 @@ end
 end
 
 @testset "monomial overflow" begin
-    R, (x, y, z) = polynomial_ring(GF(2^31 - 1), ["x", "y", "z"], internal_ordering=:degrevlex)
+    R, (x, y, z) = polynomial_ring(GF(Int64(2)^31 - 1), ["x", "y", "z"], internal_ordering=:degrevlex)
 
-    @test groebner([x^(2^31)]) == [x^2^31]
-    @test_throws Groebner.MonomialDegreeOverflow groebner([x^(2^33)])
+    @test groebner([x^(Int64(2)^31)]) == [x^Int64(2)^31]
+    @test_throws Groebner.MonomialDegreeOverflow groebner([x^(Int64(2)^33)])
 
     for monoms in [:auto, :dense, :packed, :nibblenodeg]
         gb_1 = [x * y^100 + y, x^100 * y + y^100, y^199 + 2147483646 * x^99 * y]
@@ -480,12 +480,12 @@ end
 end
 
 @testset "groebner reduced=true" begin
-    root = Groebner.Examples.rootn(3, k=GF(2^31 - 1), internal_ordering=:degrevlex)
+    root = Groebner.Examples.rootn(3, k=GF(Int64(2)^31 - 1), internal_ordering=:degrevlex)
     x1, x2, x3 = gens(parent(first(root)))
     gb = Groebner.groebner(root, reduced=true)
     @test gb == [x1 + x2 + x3, x2^2 + x2 * x3 + x3^2, x3^3 + 2147483646]
 
-    root = Groebner.Examples.rootn(6, k=GF(2^31 - 1), internal_ordering=:degrevlex)
+    root = Groebner.Examples.rootn(6, k=GF(Int64(2)^31 - 1), internal_ordering=:degrevlex)
     x1, x2, x3, x4, x5, x6 = gens(parent(first(root)))
     gb = Groebner.groebner(root, reduced=true)
     #! format: off
@@ -499,7 +499,7 @@ end
     ]
     #! format: on
 
-    ku = Groebner.Examples.ku10(k=GF(2^31 - 1), internal_ordering=:degrevlex)
+    ku = Groebner.Examples.ku10(k=GF(Int64(2)^31 - 1), internal_ordering=:degrevlex)
     x1, x2, x3, x4, x5, x6, x7, x8, x9, x10 = gens(parent(first(ku)))
     gb = Groebner.groebner(ku, reduced=true)
 
@@ -518,7 +518,7 @@ end
 end
 
 @testset "groebner certify" begin
-    R, (x, y, z) = polynomial_ring(GF(2^31 - 1), ["x", "y", "z"], internal_ordering=:lex)
+    R, (x, y, z) = polynomial_ring(GF(Int64(2)^31 - 1), ["x", "y", "z"], internal_ordering=:lex)
 
     @test Groebner.groebner([x, y], certify=true) == [y, x]
     @test Groebner.groebner([y, x], certify=true) == [y, x]
@@ -565,7 +565,7 @@ end
     system = [
         x1 + BigInt(10)^100 // BigInt(7)^50 * x2,
         BigInt(90) * x1 * x2 + BigInt(19)^50 + x10^3,
-        BigInt(2^31 - 1) * x1^2 + BigInt(2^30 + 2)^10 * x2^2
+        BigInt(Int64(2)^31 - 1) * x1^2 + BigInt(Int64(2)^30 + 2)^10 * x2^2
     ]
     @test Groebner.groebner(system) == Groebner.groebner(system, certify=true)
 end
@@ -807,13 +807,13 @@ end
 end
 
 @testset "groebner monoms" begin
-    for domain in (GF(2^31 - 1), QQ)
+    for domain in (GF(Int64(2)^31 - 1), QQ)
         for system in [
             Groebner.Examples.cyclicn(2, k=domain),
             Groebner.Examples.noonn(4, k=domain, internal_ordering=:degrevlex),
             Groebner.Examples.katsuran(5, k=domain, internal_ordering=:degrevlex),
             Groebner.Examples.kinema(k=domain, internal_ordering=:degrevlex),
-            Groebner.Examples.NFkB_reduced(k=GF(2^30 + 3), internal_ordering=:degrevlex)
+            Groebner.Examples.NFkB_reduced(k=GF(Int64(2)^30 + 3), internal_ordering=:degrevlex)
         ]
             results = []
             for monoms in [:dense, :packed, :nibblenodeg]
@@ -827,7 +827,7 @@ end
 end
 
 @testset "groebner zeros" begin
-    for field in [GF(2), GF(2^31 - 1), QQ]
+    for field in [GF(2), GF(Int64(2)^31 - 1), QQ]
         R, (x, y, z) = polynomial_ring(field, ["x", "y", "z"], internal_ordering=:lex)
 
         @test Groebner.groebner([x - x]) == [R(0)]
@@ -839,7 +839,7 @@ end
 end
 
 @testset "isgroebner zeros" begin
-    for field in [GF(2), GF(2^31 - 1), QQ]
+    for field in [GF(2), GF(Int64(2)^31 - 1), QQ]
         R, (x, y, z) = polynomial_ring(field, ["x", "y", "z"], internal_ordering=:lex)
 
         @test Groebner.isgroebner([x - x])
@@ -852,7 +852,7 @@ end
 end
 
 @testset "normalform zeros" begin
-    for field in [GF(2), GF(2^31 - 1), QQ]
+    for field in [GF(2), GF(Int64(2)^31 - 1), QQ]
         R, (x, y, z) = polynomial_ring(field, ["x", "y", "z"], internal_ordering=:lex)
 
         @test Groebner.normalform([R(0)], [R(0)]) == [R(0)]
@@ -901,7 +901,7 @@ end
 end
 
 @testset "groebner linear algebra" begin
-    R, (x, y, z) = polynomial_ring(GF(2^31 - 1), ["x", "y", "z"], internal_ordering=:lex)
+    R, (x, y, z) = polynomial_ring(GF(Int64(2)^31 - 1), ["x", "y", "z"], internal_ordering=:lex)
 
     for linalg in [:deterministic, :randomized]
         @test Groebner.groebner([x, y], linalg=linalg) == Groebner.groebner([y, x]) == [y, x]
@@ -909,19 +909,19 @@ end
         fs = [x^2 + y, x * y]
         @test Groebner.groebner(fs, linalg=linalg) == Groebner.groebner(fs) == [y^2, x * y, x^2 + y]
 
-        root = Groebner.Examples.rootn(3, k=GF(2^31 - 1), internal_ordering=:degrevlex)
+        root = Groebner.Examples.rootn(3, k=GF(Int64(2)^31 - 1), internal_ordering=:degrevlex)
         x1, x2, x3 = gens(parent(first(root)))
         gb1 = Groebner.groebner(root, linalg=linalg)
         gb2 = Groebner.groebner(root)
         @test gb1 == gb2 == [x1 + x2 + x3, x2^2 + x2 * x3 + x3^2, x3^3 + 2147483646]
 
-        root = Groebner.Examples.rootn(6, k=GF(2^31 - 1), internal_ordering=:degrevlex)
+        root = Groebner.Examples.rootn(6, k=GF(Int64(2)^31 - 1), internal_ordering=:degrevlex)
         x1, x2, x3, x4, x5, x6 = gens(parent(first(root)))
         gb1 = Groebner.groebner(root, linalg=linalg)
         gb2 = Groebner.groebner(root)
         @test gb1 == gb2
 
-        ku = Groebner.Examples.ku10(k=GF(2^31 - 1), internal_ordering=:degrevlex)
+        ku = Groebner.Examples.ku10(k=GF(Int64(2)^31 - 1), internal_ordering=:degrevlex)
         x1, x2, x3, x4, x5, x6, x7, x8, x9, x10 = gens(parent(first(ku)))
         gb1 = Groebner.groebner(ku)
         gb2 = Groebner.groebner(ku, linalg=linalg)
@@ -964,34 +964,34 @@ end
     R, (x1, x2, x3, x4) =
         polynomial_ring(QQ, ["x1", "x2", "x3", "x4"], internal_ordering=:degrevlex)
 
-    N = prod(map(BigInt, nextprimes(2^30 + 3, 5)))
+    N = prod(map(BigInt, nextprimes(Int64(2)^30 + 3, 5)))
     system, result = get_test_system1(R, N)
     # this should take about 10 primes
     gb = Groebner.groebner(system)
     @test gb == result
 
-    N = prod(map(BigInt, nextprimes(2^31 - 1, 5)))
+    N = prod(map(BigInt, nextprimes(Int64(2)^31 - 1, 5)))
     system, result = get_test_system1(R, N)
     # this should take about 10 primes
     gb = Groebner.groebner(system)
     @test gb == result
 
-    N = prod(map(BigInt, nextprimes(2^31 - 1, 100)))
+    N = prod(map(BigInt, nextprimes(Int64(2)^31 - 1, 100)))
     system, result = get_test_system1(R, N)
     # around 200 primes are required
     gb = Groebner.groebner(system)
     @test gb == result
 
-    N = prod(map(BigInt, nextprimes(2^31 - 1, 5_000)))
+    N = prod(map(BigInt, nextprimes(Int64(2)^31 - 1, 5_000)))
     # around 10k primes are required
     system, result = get_test_system1(R, N)
     gb = Groebner.groebner(system)
     @test gb == result
 
-    system = [x1 - (2^31 - 1) * x2 - (2^30 + 3) * x3]
+    system = [x1 - (Int64(2)^31 - 1) * x2 - (Int64(2)^30 + 3) * x3]
     @test Groebner.groebner(system) == system
 
-    for start_of_range in [2^10, 2^20, 2^30, 2^40]
+    for start_of_range in [2^10, 2^20, Int64(2)^30, 2^40]
         for size_of_range in [10, 100, 1000]
             N = prod(Primes.nextprimes(BigInt(start_of_range), size_of_range))
             system = [x1 + N // (N + 1), x3 - (N + 1) // (N - 1), x2 + 42]
@@ -1066,7 +1066,7 @@ end
     end
 end
 
-# For Lex, DegLex, and DegRevLex, we can have total degrees up to 2^31
+# For Lex, DegLex, and DegRevLex, we can have total degrees up to Int64(2)^31
 @testset "groebner large exponents" begin
     R, (x, y) = polynomial_ring(QQ, ["x", "y"], internal_ordering=:degrevlex)
 
@@ -1102,11 +1102,11 @@ end
         @test gb == [x^v + y^u, y^(v + u) + x^(v - u), x^u * y^v - 1]
     end
 
-    # total degree 2^30
+    # total degree Int64(2)^30
     f = [x^1073741824 + y]
     @test f == Groebner.groebner(f)
 
-    # total degree 2^31
+    # total degree Int64(2)^31
     f = [x^1073741824 * y^1073741824 + y]
     @test f == Groebner.groebner(f)
 
@@ -1216,14 +1216,14 @@ end
 end
 
 @testset "groebner, change matrix" begin
-    R, (x, y, z) = polynomial_ring(GF(2^30 + 3), ["x", "y", "z"], internal_ordering=:degrevlex)
+    R, (x, y, z) = polynomial_ring(GF(Int64(2)^30 + 3), ["x", "y", "z"], internal_ordering=:degrevlex)
     f = [x * y * z - 1, x * y + x * z + y * z, x + y + z]
     g, m = Groebner.groebner_with_change_matrix(f)
     @test m * f == g
     @test size(m) == (length(g), length(f))
     @test Groebner.isgroebner(g)
 
-    for ground in [GF(2^30 + 3), QQ]
+    for ground in [GF(Int64(2)^30 + 3), QQ]
         R, (x, y) = polynomial_ring(ground, ["x", "y"], internal_ordering=:degrevlex)
 
         cases = [
@@ -1264,7 +1264,7 @@ end
 
 @testset "multi-threading, composable" begin
     sys1 = Groebner.Examples.chandran(8)
-    sys2 = Groebner.Examples.cyclicn(7, k=GF(2^30 + 3))
+    sys2 = Groebner.Examples.cyclicn(7, k=GF(Int64(2)^30 + 3))
     n = 5
     res = Vector{Any}(undef, n)
     Base.Threads.@threads for i in 1:n
@@ -1293,7 +1293,7 @@ end
 @testset "groebner, multi-threading, Zp" begin
     @info "Testing multi-threading over Zp using $(nthreads()) threads"
 
-    R, (x, y, z) = GF(2^31 - 1)["x", "y", "z"]
+    R, (x, y, z) = GF(Int64(2)^31 - 1)["x", "y", "z"]
 
     s = [R(1), R(2), R(4)]
     @test Groebner.groebner(s) ==
@@ -1311,15 +1311,15 @@ end
     tasks = [:auto, 1, 4, 128]
     grid = [(linalg=l, tasks=t) for l in linalg for t in tasks]
     for system in [
-        Groebner.Examples.katsuran(3, internal_ordering=:lex, k=GF(2^31 - 1)),
-        Groebner.Examples.katsuran(4, internal_ordering=:lex, k=GF(2^20 + 7)),
-        Groebner.Examples.katsuran(7, internal_ordering=:degrevlex, k=GF(2^31 - 1)),
-        Groebner.Examples.eco5(internal_ordering=:deglex, k=GF(2^20 + 7)),
-        Groebner.Examples.eco5(internal_ordering=:degrevlex, k=GF(2^20 + 7)),
-        Groebner.Examples.cyclicn(5, internal_ordering=:degrevlex, k=GF(2^20 + 7)),
-        Groebner.Examples.cyclicn(6, internal_ordering=:degrevlex, k=GF(2^20 + 7)),
-        Groebner.Examples.ojika4(internal_ordering=:lex, k=GF(2^20 + 7)),
-        Groebner.Examples.henrion5(internal_ordering=:degrevlex, k=GF(2^20 + 7)),
+        Groebner.Examples.katsuran(3, internal_ordering=:lex, k=GF(Int64(2)^31 - 1)),
+        Groebner.Examples.katsuran(4, internal_ordering=:lex, k=GF(Int64(2)^20 + 7)),
+        Groebner.Examples.katsuran(7, internal_ordering=:degrevlex, k=GF(Int64(2)^31 - 1)),
+        Groebner.Examples.eco5(internal_ordering=:deglex, k=GF(Int64(2)^20 + 7)),
+        Groebner.Examples.eco5(internal_ordering=:degrevlex, k=GF(Int64(2)^20 + 7)),
+        Groebner.Examples.cyclicn(5, internal_ordering=:degrevlex, k=GF(Int64(2)^20 + 7)),
+        Groebner.Examples.cyclicn(6, internal_ordering=:degrevlex, k=GF(Int64(2)^20 + 7)),
+        Groebner.Examples.ojika4(internal_ordering=:lex, k=GF(Int64(2)^20 + 7)),
+        Groebner.Examples.henrion5(internal_ordering=:degrevlex, k=GF(Int64(2)^20 + 7)),
         Groebner.Examples.noonn(6, internal_ordering=:degrevlex, k=GF(2^10 + 7)),
         Groebner.Examples.ku10(internal_ordering=:degrevlex, k=GF(2^10 + 7))
     ]
@@ -1452,7 +1452,7 @@ end
     nterms     = [1, 2, 4]
     npolys     = [1, 4, 100]
     grounds    = [GF(1031), GF(2^50 + 55), AbstractAlgebra.QQ]
-    coeffssize = [3, 2^31 - 1, BigInt(2)^80, BigInt(2)^2000]
+    coeffssize = [3, Int64(2)^31 - 1, BigInt(2)^80, BigInt(2)^2000]
     orderings  = [:degrevlex, :lex, :deglex]
     linalgs    = [:deterministic, :randomized]
     monoms     = [:auto, :dense, :packed, :nibblenodeg]

--- a/test/groebner.jl
+++ b/test/groebner.jl
@@ -318,8 +318,10 @@ end
         @test Groebner.groebner([x + Int64(2)^31 - 1, x^2], modular=modular) == [1]
         @test Groebner.groebner([(3232323 // 7777)x + 7777 // 3232323], modular=modular) ==
               [x + 60481729 // 10447911976329]
-        @test Groebner.groebner([((Int64(2)^31 - 1) // 1)x + 1], modular=modular) == [x + 1 // 2147483647]
-        @test Groebner.groebner([(1 // (Int64(2)^31 - 1))x + 1], modular=modular) == [x + 2147483647]
+        @test Groebner.groebner([((Int64(2)^31 - 1) // 1)x + 1], modular=modular) ==
+              [x + 1 // 2147483647]
+        @test Groebner.groebner([(1 // (Int64(2)^31 - 1))x + 1], modular=modular) ==
+              [x + 2147483647]
         @test Groebner.groebner(
             [1 // (Int64(2)^30 + 3) * x^2 + (Int64(2)^30 + 3)x + 1 // (1073741831)],
             modular=modular
@@ -442,7 +444,8 @@ end
 end
 
 @testset "monomial overflow" begin
-    R, (x, y, z) = polynomial_ring(GF(Int64(2)^31 - 1), ["x", "y", "z"], internal_ordering=:degrevlex)
+    R, (x, y, z) =
+        polynomial_ring(GF(Int64(2)^31 - 1), ["x", "y", "z"], internal_ordering=:degrevlex)
 
     @test groebner([x^(Int64(2)^31)]) == [x^Int64(2)^31]
     @test_throws Groebner.MonomialDegreeOverflow groebner([x^(Int64(2)^33)])
@@ -1216,7 +1219,8 @@ end
 end
 
 @testset "groebner, change matrix" begin
-    R, (x, y, z) = polynomial_ring(GF(Int64(2)^30 + 3), ["x", "y", "z"], internal_ordering=:degrevlex)
+    R, (x, y, z) =
+        polynomial_ring(GF(Int64(2)^30 + 3), ["x", "y", "z"], internal_ordering=:degrevlex)
     f = [x * y * z - 1, x * y + x * z + y * z, x + y + z]
     g, m = Groebner.groebner_with_change_matrix(f)
     @test m * f == g

--- a/test/input_output/AbstractAlgebra.jl
+++ b/test/input_output/AbstractAlgebra.jl
@@ -6,7 +6,7 @@ using AbstractAlgebra, Test, Primes, Groebner
     @test Groebner.groebner([R(0), R(0)]) == [R(0)]
     @test Groebner.groebner([R(0), R(3), R(0)]) == [R(1)]
 
-    for ground in [GF(2^31 - 1), GF(2^62 + 135), QQ]
+    for ground in [GF(Int64(2)^31 - 1), GF(2^62 + 135), QQ]
         for gb_ord in [Groebner.Lex(), Groebner.DegLex(), Groebner.DegRevLex()]
             R, x = polynomial_ring(ground, "x")
             @test Groebner.groebner([x^2 - 4, x + 2], ordering=gb_ord) == [x + 2]
@@ -32,7 +32,7 @@ end
     aa_orderings_to_test = [:lex, :degrevlex, :deglex]
     aa_grounds_to_test = [
         AbstractAlgebra.GF(2^62 + 135),
-        AbstractAlgebra.GF(2^31 - 1),
+        AbstractAlgebra.GF(Int64(2)^31 - 1),
         AbstractAlgebra.GF(17),
         AbstractAlgebra.QQ
     ]

--- a/test/input_output/Nemo.jl
+++ b/test/input_output/Nemo.jl
@@ -11,7 +11,7 @@ using Test, Nemo, Groebner
     end
 
     for ff in [
-        Nemo.Native.GF(2^31 - 1),
+        Nemo.Native.GF(Int64(2)^31 - 1),
         Nemo.Native.GF(2^62 + 135),
         Nemo.GF(2^62 + 135),
         Nemo.GF(Nemo.ZZRingElem(2^62 + 135)),
@@ -83,10 +83,10 @@ end
     nemo_orderings_to_test = [:lex, :deglex, :degrevlex]
     nemo_grounds_to_test = [
         Nemo.Native.GF(2^62 + 135),
-        Nemo.Native.GF(2^31 - 1),
+        Nemo.Native.GF(Int64(2)^31 - 1),
         Nemo.Native.GF(17),
         Nemo.GF(2^62 + 135),
-        Nemo.GF(2^31 - 1),
+        Nemo.GF(Int64(2)^31 - 1),
         Nemo.QQ
     ]
 
@@ -104,14 +104,14 @@ end
         end
     end
 
-    c = Groebner.Examples.cyclicn(6, k=Nemo.GF(2^30 + 3))
+    c = Groebner.Examples.cyclicn(6, k=Nemo.GF(Int64(2)^30 + 3))
     gb1 = Groebner.groebner(c)
     trace, gb2 = Groebner.groebner_learn(c)
     flag, gb3 = Groebner.groebner_apply!(trace, c)
     flag, _gb4 = Groebner.groebner_apply!(trace, (c, c, c, c))
     @test gb1 == gb2 == gb3 == _gb4[1]
 
-    c = Groebner.Examples.cyclicn(6, k=Nemo.Native.GF(2^30 + 3))
+    c = Groebner.Examples.cyclicn(6, k=Nemo.Native.GF(Int64(2)^30 + 3))
     gb1 = Groebner.groebner(c)
     trace, gb2 = Groebner.groebner_learn(c)
     flag, gb3 = Groebner.groebner_apply!(trace, c)

--- a/test/isgroebner.jl
+++ b/test/isgroebner.jl
@@ -1,12 +1,12 @@
 using Test, AbstractAlgebra, Groebner
 
 @testset "isgroebner" begin
-    R, x = polynomial_ring(GF(2^31 - 1), "x")
+    R, x = polynomial_ring(GF(Int64(2)^31 - 1), "x")
     @test Groebner.isgroebner([x])
     @test Groebner.isgroebner([x, x, x, x])
     @test !Groebner.isgroebner([x^2, x^2 + 1])
 
-    R, (x, y, z) = polynomial_ring(GF(2^31 - 1), ["x", "y", "z"], internal_ordering=:degrevlex)
+    R, (x, y, z) = polynomial_ring(GF(Int64(2)^31 - 1), ["x", "y", "z"], internal_ordering=:degrevlex)
 
     @test Groebner.isgroebner([R(1)])
     @test Groebner.isgroebner([x])
@@ -41,7 +41,7 @@ using Test, AbstractAlgebra, Groebner
 end
 
 @testset "isgroebner orderings" begin
-    R, (x, y, z) = polynomial_ring(GF(2^31 - 1), ["x", "y", "z"])
+    R, (x, y, z) = polynomial_ring(GF(Int64(2)^31 - 1), ["x", "y", "z"])
 
     @test Groebner.isgroebner([x^2 + y, y])
     @test Groebner.isgroebner([x^2 + y, y], ordering=Groebner.Lex(x, y, z))
@@ -53,7 +53,7 @@ end
 
 @testset "isgroebner certify" begin
     for certify in [false, true]
-        for field in [GF(17), GF(2^31 - 1), QQ]
+        for field in [GF(17), GF(Int64(2)^31 - 1), QQ]
             R, (x, y, z) = polynomial_ring(field, ["x", "y", "z"], internal_ordering=:degrevlex)
 
             @test Groebner.isgroebner([R(0)], certify=certify)
@@ -66,7 +66,7 @@ end
             @test !Groebner.isgroebner([x + y, x], certify=certify)
             @test Groebner.isgroebner([z * x, z * x, R(1)], certify=certify)
         end
-        fs = Groebner.Examples.rootn(3, k=GF(2^31 - 1), internal_ordering=:degrevlex)
+        fs = Groebner.Examples.rootn(3, k=GF(Int64(2)^31 - 1), internal_ordering=:degrevlex)
         @test !Groebner.isgroebner(fs, certify=certify)
         @test Groebner.isgroebner(Groebner.groebner(fs), certify=certify)
 
@@ -74,7 +74,7 @@ end
         @test !Groebner.isgroebner(fs, certify=certify)
         @test Groebner.isgroebner(Groebner.groebner(fs), certify=certify)
 
-        fs = Groebner.Examples.noonn(2, k=GF(2^31 - 1), internal_ordering=:degrevlex)
+        fs = Groebner.Examples.noonn(2, k=GF(Int64(2)^31 - 1), internal_ordering=:degrevlex)
         @test !Groebner.isgroebner(fs, certify=certify)
         @test Groebner.isgroebner(Groebner.groebner(fs), certify=certify)
 
@@ -82,7 +82,7 @@ end
         @test !Groebner.isgroebner(fs, certify=certify)
         @test Groebner.isgroebner(Groebner.groebner(fs), certify=certify)
 
-        fs = Groebner.Examples.noonn(6, k=GF(2^31 - 1), internal_ordering=:degrevlex)
+        fs = Groebner.Examples.noonn(6, k=GF(Int64(2)^31 - 1), internal_ordering=:degrevlex)
         @test !Groebner.isgroebner(fs, certify=certify)
         @test Groebner.isgroebner(Groebner.groebner(fs), certify=certify)
     end

--- a/test/isgroebner.jl
+++ b/test/isgroebner.jl
@@ -6,7 +6,8 @@ using Test, AbstractAlgebra, Groebner
     @test Groebner.isgroebner([x, x, x, x])
     @test !Groebner.isgroebner([x^2, x^2 + 1])
 
-    R, (x, y, z) = polynomial_ring(GF(Int64(2)^31 - 1), ["x", "y", "z"], internal_ordering=:degrevlex)
+    R, (x, y, z) =
+        polynomial_ring(GF(Int64(2)^31 - 1), ["x", "y", "z"], internal_ordering=:degrevlex)
 
     @test Groebner.isgroebner([R(1)])
     @test Groebner.isgroebner([x])

--- a/test/learn_and_apply.jl
+++ b/test/learn_and_apply.jl
@@ -1,7 +1,7 @@
 using Test, Random, AbstractAlgebra, Primes, Groebner
 
 @testset "learn & apply, same field" begin
-    K = AbstractAlgebra.GF(2^31 - 1)
+    K = AbstractAlgebra.GF(Int64(2)^31 - 1)
     R, (x, y) = polynomial_ring(K, ["x", "y"]; internal_ordering=:degrevlex)
     trace, gb1 = Groebner.groebner_learn([x, y])
     flag, gb2 = Groebner.groebner_apply!(trace, [x, y])
@@ -9,7 +9,7 @@ using Test, Random, AbstractAlgebra, Primes, Groebner
 
     show(trace)
 
-    K = AbstractAlgebra.GF(2^31 - 1)
+    K = AbstractAlgebra.GF(Int64(2)^31 - 1)
     R, (x, y) = polynomial_ring(K, ["x", "y"], internal_ordering=:degrevlex)
     R2, xs = polynomial_ring(K, ["x$i" for i in 1:30], internal_ordering=:degrevlex)
 
@@ -107,7 +107,7 @@ end
 
     # Going from small characteristic to large is not allowed
     # NOTE: it should be allowed
-    K1, K2 = GF(2^31 - 1), GF(2^60 + 33)
+    K1, K2 = GF(Int64(2)^31 - 1), GF(2^60 + 33)
     R, (x, y) = polynomial_ring(K1, ["x", "y"], internal_ordering=:degrevlex)
     R2, (x2, y2) = polynomial_ring(K2, ["x", "y"], internal_ordering=:degrevlex)
     system2 = [(2^49 + 1) * x2 - 1, (2^50) * y2 + (2^56 + 99)]
@@ -118,7 +118,7 @@ end
     # @test_broken gb_2 == [y2 + (2^56 + 99) // K2(2^50), x2 - 1 // K2(2^49 + 1)]
 
     # The trace ordering is reused unless an incompatible ordering is requested.
-    K1, K2 = GF(2^31 - 1), GF(2^60 + 33)
+    K1, K2 = GF(Int64(2)^31 - 1), GF(2^60 + 33)
     R, (x, y) = polynomial_ring(K1, ["x", "y"], internal_ordering=:lex)
     R2, (x2, y2) = polynomial_ring(K2, ["x", "y"], internal_ordering=:degrevlex)
     system = [x + 1, y - 1]
@@ -127,7 +127,7 @@ end
     flag, gb_2 = Groebner.groebner_apply!(trace, system2)
     @test flag && gb_2 == Groebner.groebner(system2; ordering=Groebner.Lex())
 
-    K1, K2 = GF(2^31 - 1), GF(2^60 + 33)
+    K1, K2 = GF(Int64(2)^31 - 1), GF(2^60 + 33)
     R, (x, y) = polynomial_ring(K1, ["x", "y"], internal_ordering=:lex)
     R2, (x2, y2) = polynomial_ring(K2, ["x", "y"], internal_ordering=:degrevlex)
     system = [x + 1, y - 1]
@@ -167,10 +167,10 @@ end
     ]
 
     # Some bigger tests
-    K = AbstractAlgebra.GF(2^31 - 1)
+    K = AbstractAlgebra.GF(Int64(2)^31 - 1)
     Ks = [
-        AbstractAlgebra.GF(2^31 - 1),
-        AbstractAlgebra.GF(2^30 + 3),
+        AbstractAlgebra.GF(Int64(2)^31 - 1),
+        AbstractAlgebra.GF(Int64(2)^30 + 3),
         AbstractAlgebra.GF(2^31 + 11),
         AbstractAlgebra.GF(2^20 + 7),
         AbstractAlgebra.GF(2^20 + 13),
@@ -200,7 +200,7 @@ end
         end
     end
 
-    K1 = GF(2^31 - 1)
+    K1 = GF(Int64(2)^31 - 1)
     R, (x, y) = polynomial_ring(ZZ, ["x", "y"], internal_ordering=:lex)
     system = [BigInt(2)^1000 * x + (BigInt(2)^1001 + 1) * y + 1]
     system_zp = map(f -> AbstractAlgebra.map_coefficients(c -> K1(BigInt(c)), f), system)
@@ -337,7 +337,7 @@ end
     end
 
     @testset "forced generic agrees" begin
-        K = GF(2^30 + 3)
+        K = GF(Int64(2)^30 + 3)
         sys1 = Groebner.Examples.katsuran(4, internal_ordering=:degrevlex, k=K)
         sys2 = Groebner.Examples.katsuran(4, internal_ordering=:lex, k=K)
 
@@ -360,7 +360,7 @@ end
     end
 
     @testset "generic reuse after failure" begin
-        K = GF(2^30 + 3)
+        K = GF(Int64(2)^30 + 3)
         R, (x, y) = polynomial_ring(K, ["x", "y"], internal_ordering=:degrevlex)
         sys_ok = [x + 1, x * y + 7 * y]
         sys_fail = [x + 1, x * y + y]
@@ -407,7 +407,7 @@ end
 end
 
 @testset "learn & apply, orderings" begin
-    K = GF(2^31 - 1)
+    K = GF(Int64(2)^31 - 1)
     R, (x, y) = polynomial_ring(K, ["x", "y"], internal_ordering=:lex)
 
     ord_1 = Groebner.Lex()
@@ -429,7 +429,7 @@ end
         ordering=Groebner.Lex()
     )
 
-    K = GF(2^31 - 1)
+    K = GF(Int64(2)^31 - 1)
     n = 10
     R, x = polynomial_ring(K, [["x$i" for i in 1:n]...], internal_ordering=:degrevlex)
     F = (x .+ (1:n) .* circshift(x, 1)) .^ 2
@@ -460,7 +460,7 @@ end
 end
 
 @testset "learn & apply, copy trace" begin
-    K1, K2 = GF(2^30 + 3), GF(2^31 - 1)
+    K1, K2 = GF(Int64(2)^30 + 3), GF(Int64(2)^31 - 1)
     R1, (x1, y1) = polynomial_ring(K1, ["x", "y"])
     R2, (x2, y2) = polynomial_ring(K2, ["x", "y"])
 
@@ -479,7 +479,7 @@ end
 end
 
 @testset "learn & apply, tricky" begin
-    for K in [GF(2^31 - 1), GF(2^62 + 135)]
+    for K in [GF(Int64(2)^31 - 1), GF(2^62 + 135)]
         R, (x, y) = polynomial_ring(K, ["x", "y"], internal_ordering=:degrevlex)
 
         s = [x^100 * y + y^100, x * y^100 + y]
@@ -501,7 +501,7 @@ end
         end
     end
 
-    K = AbstractAlgebra.GF(2^31 - 1)
+    K = AbstractAlgebra.GF(Int64(2)^31 - 1)
     R, (x, y) = polynomial_ring(K, ["x", "y"], internal_ordering=:degrevlex)
 
     # s-poly of x + 1 and x*y + 7y is y - 7y.
@@ -595,7 +595,7 @@ end
         @test (flag3, gb_coeffs3) == (flag4, gb_coeffs4)
     end
 
-    R, (x, y) = polynomial_ring(GF(2^31 - 1), ["x", "y"], internal_ordering=:degrevlex)
+    R, (x, y) = polynomial_ring(GF(Int64(2)^31 - 1), ["x", "y"], internal_ordering=:degrevlex)
 
     ring = Groebner.PolyRing(2, Groebner.DegRevLex(), 2^31 - 1)
     @test_throws DomainError Groebner.groebner_learn(ring, [], [])
@@ -634,7 +634,7 @@ end
     ring = Groebner.PolyRing(5, Groebner.DegRevLex(), 2^40 + 15)
     test_low_level_interface(ring, sys)
 
-    sys = Groebner.Examples.cyclicn(5, k=GF(2^30 + 3))
+    sys = Groebner.Examples.cyclicn(5, k=GF(Int64(2)^30 + 3))
     ring = Groebner.PolyRing(5, Groebner.DegRevLex(), 2^30 + 3)
     test_low_level_interface(ring, sys; ordering=Groebner.DegRevLex())
 end

--- a/test/normalform.jl
+++ b/test/normalform.jl
@@ -30,7 +30,8 @@ using Test, Groebner, AbstractAlgebra, Random
     @test Groebner.normalform(G, x^2 + y^2) == y - y * x - 1
     @test Groebner.normalform(G, y^3) == Groebner.normalform(G, y^4) == y
 
-    R, (x, y, z) = polynomial_ring(GF(Int64(2)^31 - 1), ["x", "y", "z"], internal_ordering=:degrevlex)
+    R, (x, y, z) =
+        polynomial_ring(GF(Int64(2)^31 - 1), ["x", "y", "z"], internal_ordering=:degrevlex)
     G = [x^2 + y, y^2 + x]
     @test Groebner.normalform(G, x^2 + y^2) == -x - y
 

--- a/test/normalform.jl
+++ b/test/normalform.jl
@@ -1,7 +1,7 @@
 using Test, Groebner, AbstractAlgebra, Random
 
 @testset "normalform" begin
-    R, x = polynomial_ring(GF(2^31 - 1), "x")
+    R, x = polynomial_ring(GF(Int64(2)^31 - 1), "x")
 
     @test Groebner.normalform([x], R(0)) == R(0)
     @test Groebner.normalform([x], R(1)) == R(1)
@@ -9,7 +9,7 @@ using Test, Groebner, AbstractAlgebra, Random
     @test Groebner.normalform([x], [R(1)]) == [R(1)]
     @test Groebner.normalform([x], [x, R(5), x + 1]) == [R(0), R(5), R(1)]
 
-    R, (x, y, z) = polynomial_ring(GF(2^31 - 1), ["x", "y", "z"])
+    R, (x, y, z) = polynomial_ring(GF(Int64(2)^31 - 1), ["x", "y", "z"])
 
     @test Groebner.normalform([x], R(0)) == R(0)
     @test Groebner.normalform([x], R(1)) == R(1)
@@ -30,7 +30,7 @@ using Test, Groebner, AbstractAlgebra, Random
     @test Groebner.normalform(G, x^2 + y^2) == y - y * x - 1
     @test Groebner.normalform(G, y^3) == Groebner.normalform(G, y^4) == y
 
-    R, (x, y, z) = polynomial_ring(GF(2^31 - 1), ["x", "y", "z"], internal_ordering=:degrevlex)
+    R, (x, y, z) = polynomial_ring(GF(Int64(2)^31 - 1), ["x", "y", "z"], internal_ordering=:degrevlex)
     G = [x^2 + y, y^2 + x]
     @test Groebner.normalform(G, x^2 + y^2) == -x - y
 
@@ -64,7 +64,7 @@ end
 end
 
 @testset "normalform of an array" begin
-    for field in [GF(17), GF(2^31 - 1), QQ]
+    for field in [GF(17), GF(Int64(2)^31 - 1), QQ]
         R, (x, y) = polynomial_ring(field, ["x", "y"])
         gb = [x, y]
         @test Groebner.normalform(gb, [x, y + 1]) == [R(0), R(1)]
@@ -178,7 +178,7 @@ end
     exps = [2, 4, 3]
     nterms = [2, 3]
     npolys = [2, 3]
-    grounds = [GF(2^31 - 1), QQ]
+    grounds = [GF(Int64(2)^31 - 1), QQ]
     coeffssize = [3, 1000, 2^31 - 1]
     orderings = [:deglex, :lex, :degrevlex]
     orderings_groebner =

--- a/test/output_inferred.jl
+++ b/test/output_inferred.jl
@@ -8,7 +8,7 @@ using Test, Groebner, AbstractAlgebra
     @test @inferred Groebner.isgroebner([x, y]) == true
 
     R, (x, y) =
-        polynomial_ring(AbstractAlgebra.GF(2^31 - 1), ["x", "y"]; internal_ordering=:degrevlex)
+        polynomial_ring(AbstractAlgebra.GF(Int64(2)^31 - 1), ["x", "y"]; internal_ordering=:degrevlex)
     @test @inferred Groebner.groebner([x, y]) == [y, x]
     @test @inferred Groebner.normalform([x, y], x + 1) == R(1)
     @test @inferred Groebner.normalform([x, y], [x + 1, y + 1, R(0)]) == [R(1), R(1), R(0)]

--- a/test/output_inferred.jl
+++ b/test/output_inferred.jl
@@ -7,8 +7,11 @@ using Test, Groebner, AbstractAlgebra
     @test @inferred Groebner.normalform([x, y], [x + 1, y + 1, R(0)]) == [R(1), R(1), R(0)]
     @test @inferred Groebner.isgroebner([x, y]) == true
 
-    R, (x, y) =
-        polynomial_ring(AbstractAlgebra.GF(Int64(2)^31 - 1), ["x", "y"]; internal_ordering=:degrevlex)
+    R, (x, y) = polynomial_ring(
+        AbstractAlgebra.GF(Int64(2)^31 - 1),
+        ["x", "y"];
+        internal_ordering=:degrevlex
+    )
     @test @inferred Groebner.groebner([x, y]) == [y, x]
     @test @inferred Groebner.normalform([x, y], x + 1) == R(1)
     @test @inferred Groebner.normalform([x, y], [x + 1, y + 1, R(0)]) == [R(1), R(1), R(0)]

--- a/test/regressions.jl
+++ b/test/regressions.jl
@@ -20,7 +20,7 @@ using Test, Primes, Groebner, AbstractAlgebra
 end
 
 @testset "regression, SI.jl normalform" begin
-    R, (x, y, z) = polynomial_ring(GF(2^31 - 1), ["x", "y", "z"])
+    R, (x, y, z) = polynomial_ring(GF(Int64(2)^31 - 1), ["x", "y", "z"])
 
     @test Groebner.normalform([x], R(0)) == R(0)
     @test Groebner.normalform([x], R(1)) == R(1)
@@ -30,7 +30,7 @@ end
 end
 
 @testset "regression, ordering of empty" begin
-    R, (x, y) = polynomial_ring(GF(2^31 - 1), ["x", "y"], internal_ordering=:lex)
+    R, (x, y) = polynomial_ring(GF(Int64(2)^31 - 1), ["x", "y"], internal_ordering=:lex)
 
     ord = Groebner.DegRevLex()
     gb1 = Groebner.groebner([x, y], ordering=ord)


### PR DESCRIPTION
## Summary
- `crt_precompute!` / `crt!` expect `Vector{UInt}`, but callers used `map(UInt64, …)` / `Vector{UInt64}`
- On 32-bit Julia (`UInt === UInt32`) that MethodError'd (seen from Symbolics x86 CI after SymbolicUtils 4.46.3)
- Use native `UInt` buffers and accept `Unsigned` in the Windows-safe `my_*_ui!` helpers

## Test plan
- [ ] Existing CRT tests on x64
- [ ] Symbolics/Groebner precompile on Julia x86


Made with [Cursor](https://cursor.com)